### PR TITLE
Ijr updates

### DIFF
--- a/Intro_markdown.Rmd
+++ b/Intro_markdown.Rmd
@@ -153,7 +153,7 @@ You can check what the working directory currently is by using the `getwd()` com
 getwd()
 ```
 
-If you want to change the working directory to a specific repository/folder - in this case `IntroRTraining`, you can use the `setwd()` command as follows:
+If you want to change the working directory to a specific repository/folder - in this case `IntroRTraining` - you can use the `setwd()` command as follows:
 
 ```{r}
 setwd("~/IntroRTraining")

--- a/Intro_markdown.Rmd
+++ b/Intro_markdown.Rmd
@@ -233,7 +233,7 @@ Although including the library call makes the code longer, it also makes it more
 
 However there are exceptions to this. In particular, we want to use the operator `%>%` (pipe) without specifying the package name, because it would be bad for our readability. So we do want to load the package `magrittr`.
 
-Please load `magrittr` by one of the methods described above (which do you you think would be best practice overall)?
+If you haven't already, load `magrittr` by one of the methods described above (which do you you think would be best practice overall)?
 
 To know more about a package, it is always useful to read the associated documentation:
 
@@ -507,7 +507,7 @@ But if we want to count all the rows in the `regional_gender_average` dataset wi
 ```{r results="hide"}
 regional_gender_average %>% 
  dplyr::ungroup() %>% 
- dplyr::summarise(Count = dlyr::n())
+ dplyr::summarise(Count = dplyr::n())
 ```
 The `summarise(Count = n())` above can also be replaced with `tally()` to count the number of rows in a dataset.
 

--- a/Intro_markdown.Rmd
+++ b/Intro_markdown.Rmd
@@ -153,7 +153,7 @@ You can check what the working directory currently is by using the `getwd()` com
 getwd()
 ```
 
-If you want to change the working directory to a specific repository/folder, you can use the `setwd()` command as follows:
+If you want to change the working directory to a specific repository/folder - in this case `IntroRTraining`, you can use the `setwd()` command as follows:
 
 ```{r}
 setwd("~/IntroRTraining")
@@ -191,7 +191,7 @@ To synchronise your working R environment with this course's repo, run
 ```{r eval = FALSE}
 renv::restore()
 ```
-If you have no installed `renv` yet, you can do this with
+If you have not installed `renv` yet, you can do this with
 
 ```{r eval = FALSE}
 install.packages('renv')
@@ -227,9 +227,9 @@ lubridate::days_in_month(Sys.Date())
 
 Here we're using function `days_in_month()` from the `lubridate` package. We're passing to it the current date.
 
-Functions that are 'base' R, or part of a core package such as the `stats` package, which we use below, do not require.
+Functions that are 'base' R, or part of a core package such as the `stats` package, which we use below, do not require the package/library name to precede the function name when the function is called.
 
-Although including the library call makes the code longer, it also makes it more readable, as anyone who is unfamiliar with the code can see very easily where functions are being called, and which packages are being used. It also avoids the wrong function being called if two functions have the same name and are from different packages. If the package isn't specified by using the double-colon notation then R will use the function from your most recently loaded package and will warn you when you load a package if there is some overlap.
+Although including the library call makes the code longer, it also makes it more readable, as anyone who is unfamiliar with the code can see very easily where functions are being called, and which packages are being used. It also avoids the wrong function being called if two functions have the same name and are from different packages. If the package isn't specified by using the double-colon notation then R will use the function from your most recently loaded package. You will be warned about any overlaps when you load a package.
 
 However there are exceptions to this. In particular, we want to use the operator `%>%` (pipe) without specifying the package name, because it would be bad for our readability. So we do want to load the package `magrittr`.
 
@@ -267,10 +267,26 @@ Note that this code is only suitable for csv files, so it is assumed by default 
 
 There are other commands and various packages that can be used to import datasets with other extensions (e.g. .xls) e.g. see http://www.statmethods.net/input/importingdata.html.
 
-
 ### Importing data from the Analytical Platform cloud storage (Amazon S3)
 
-Data that has been approved for storage on the Analytical Platform is generally stored in a data source (referred to as a 'bucket') on Amazon S3, which is the cloud storage solution used by the Analytical Platform. To import data from S3 we use `botor`.
+Data that has been approved for storage on the Analytical Platform is generally stored in a data source (referred to as a 'bucket') on Amazon S3, which is the cloud storage solution used by the Analytical Platform. There are two options for packages that can be used to import data from S3: `Rs3tools` and `botor`.
+
+#### Importing data using the `Rs3tools` package {-}
+
+The `Rs3tools` package is maintained by other analysts in MoJ and has the advantage of being R-native, resulting in it being quicker to install than `botor` (which requires a Python environment). Here's how it can be installed:
+
+```{r, results="hide"}
+install.packages("moj-analytical-services/Rs3tools")
+```
+
+And here's how to use `Rs3tools` to read in the `offenders` dataset that we'll be using in this session from the 'alpha-r-training' S3 bucket:
+
+```{r, results="hide"}
+offenders <- Rs3tools::s3_path_to_full_df(
+  s3_path = "alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv")
+```
+
+#### Importing data using the `botor` package {-}
 
 The `botor` package provides an alternative to `Rs3tools`. It's maintained by the wider R community and contains a larger range of functionality. Reading from S3 using `botor` can be done using this command:
 
@@ -279,9 +295,7 @@ offenders <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv",
   fun = readr::read_csv)
 ```
-
-More information on `botor` can be found on the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
-
+More information on `Rs3tools` and `botor` can be found in the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
 
 ## Inspecting the dataset
 

--- a/Intro_markdown.Rmd
+++ b/Intro_markdown.Rmd
@@ -276,7 +276,7 @@ Data that has been approved for storage on the Analytical Platform is generally 
 The `Rs3tools` package is maintained by other analysts in MoJ and has the advantage of being R-native, resulting in it being quicker to install than `botor` (which requires a Python environment). Here's how it can be installed:
 
 ```{r, results="hide"}
-install.packages("moj-analytical-services/Rs3tools")
+renv::install("moj-analytical-services/Rs3tools")
 ```
 
 And here's how to use `Rs3tools` to read in the `offenders` dataset that we'll be using in this session from the 'alpha-r-training' S3 bucket:
@@ -295,6 +295,10 @@ offenders <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv",
   fun = readr::read_csv)
 ```
+
+Here we are passing another function to `botor::s3_read` which it uses to read the data
+from the uri.
+
 More information on `Rs3tools` and `botor` can be found in the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
 
 ## Inspecting the dataset
@@ -658,13 +662,24 @@ offenders <- offenders %>%
 
 There are `dplyr` functions `left_join()`, `right_join()`, `inner_join()`, `full_join()`, `semi_join()` and `anti_join()` which can merge data sets, provided you have some common fields to match on. This is similar to SQL.
 
-Let's import a new dataset which contains information on whether the offenders faced trial. Use either of the following commands, depending on whether you're using the Analytical Platform version of RStudio or a local version:
+Let's import a new dataset which contains information on whether the offenders faced trial. Use one of the following commands:
+
+Using Rs3tools
+
+```{r results="hide"}
+offenders_trial <-  Rs3tools::s3_path_to_full_df(
+  s3_path = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv")
+```
+
+Using botor:
 
 ```{r results="hide"}
 offenders_trial <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv",
   fun = readr::read_csv)
 ```
+
+Using local file read:
 
 ```{r eval=FALSE, results="hide"}
 offenders_trial <- readr::read_csv("Offenders_Chicago_Police_Dept_Trial.csv")

--- a/Intro_markdown.Rmd
+++ b/Intro_markdown.Rmd
@@ -156,7 +156,7 @@ getwd()
 If you want to change the working directory to a specific repository/folder, you can use the `setwd()` command as follows:
 
 ```{r}
-setwd("~/folder_name")
+setwd("~/IntroRTraining")
 ```
 
 Alternatively, you can set your working directory following the steps below:
@@ -181,29 +181,67 @@ Your new directory will be automatically set as the working directory. If you ha
 
 A lot of pre-programmed routines are included in R, and you can add a lot more through packages. One characteristic that's important to recognize is that just as there are many ways of getting from Victoria Station to 102 Petty France, there are many ways of doing the same thing in R. Some ways are (computationally) faster, some are simpler to program, and some may be more conducive to your taste.  
 
-Packages extend R's functionality enormously and are a key factor in making R so popular. For instance, to install the `tidyverse` suite of packages in R, which we recommend you use for data manipulation and analysis, use the Install button from the Packages tab in Rstudio. 
+Packages (also known as libraries) extend R's functionality enormously and are a key factor in making R so popular.
 
-This runs the following command:
+Assuming that you are working with R on the AP, you are encouraged to use the
+package `renv` to manage your packages.
+
+To synchronise your working R environment with this course's repo, run
 
 ```{r eval = FALSE}
-install.packages("tidyverse")
+renv::restore()
+```
+If you have no installed `renv` yet, you can do this with
+
+```{r eval = FALSE}
+install.packages('renv')
 ```
 
-Note that if you are using R on the Analytical Platform the tidyverse package may already be installed, hence the above step can be skipped. 
+If prompted to update, enter Y for Yes. This should now update your project 
+environment.
 
-Once a package is installed, you should be able to see it in the packages tab. If you want to use it, you can load it by ticking the appropriate box in the packages window. You can also load packages using the library command, which you can put inside your script, so they will automatically load when you run it:
+This is the command to install/update a package using `renv`:
 
-```{r results=FALSE, warning=FALSE, comment=FALSE}
-library("tidyverse")
+```{r eval = FALSE}
+renv::install('tidyverse')
 ```
+
+Run this, and the tidyverse package (actually a suite of packages) should update
+to a more recent version.
 
 The package suite `tidyverse` contains many useful packages such as `dplyr` which is a particularly useful package for manipulating and processing data. Many of the functions in the rest of this introductory training are from this package.
+
+There are different ways of using packages  It is possible to load them with library calls, usually found at the start of scripts, e.g.
+
+```{r results=FALSE, warning=FALSE, comment=FALSE}
+library("magrittr")
+```
+
+You can also load packages via the GUI. You should be able to see them in the packages tab. You can load them by ticking the appropriate box in the packages window.
+
+However, for the most part it is considered best practice to not rely on having libraries loaded, but instead to specify them when they are being called, e.g.
+
+```{r results=FALSE, warning=FALSE, comment=FALSE}
+lubridate::days_in_month(Sys.Date())
+```
+
+Here we're using function `days_in_month()` from the `lubridate` package. We're passing to it the current date.
+
+Functions that are 'base' R, or part of a core package such as the `stats` package, which we use below, do not require.
+
+Although including the library call makes the code longer, it also makes it more readable, as anyone who is unfamiliar with the code can see very easily where functions are being called, and which packages are being used. It also avoids the wrong function being called if two functions have the same name and are from different packages. If the package isn't specified by using the double-colon notation then R will use the function from your most recently loaded package and will warn you when you load a package if there is some overlap.
+
+However there are exceptions to this. In particular, we want to use the operator `%>%` (pipe) without specifying the package name, because it would be bad for our readability. So we do want to load the package `magrittr`.
+
+Please load `magrittr` by one of the methods described above (which do you you think would be best practice overall)?
 
 To know more about a package, it is always useful to read the associated documentation:
 
 ```{r results="hide"}
 ?dplyr
 ```
+
+
 
 ## Importing data
 
@@ -232,31 +270,17 @@ There are other commands and various packages that can be used to import dataset
 
 ### Importing data from the Analytical Platform cloud storage (Amazon S3)
 
-Data that has been approved for storage on the Analytical Platform is generally stored in a data source (referred to as a 'bucket') on Amazon S3, which is the cloud storage solution used by the Analytical Platform. There are two options for packages that can be used to import data from S3: `Rs3tools` and `botor`.
-
-#### Importing data using the `Rs3tools` package {-}
-
-The `Rs3tools` package is maintained by other analysts in MoJ and has the advantage of being R-native, resulting in it being quicker to install than `botor` (which requires a Python environment). Here's how it can be installed:
-
-```{r, results="hide"}
-install.packages("moj-analytical-services/Rs3tools")
-```
-
-And here's how to use `Rs3tools` to read in the `offenders` dataset that we'll be using in this session from the 'alpha-r-training' S3 bucket:
-
-```{r, results="hide"}
-offenders <- Rs3tools::s3_path_to_full_df("alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv")
-```
-
-#### Importing data using the `botor` package {-}
+Data that has been approved for storage on the Analytical Platform is generally stored in a data source (referred to as a 'bucket') on Amazon S3, which is the cloud storage solution used by the Analytical Platform. To import data from S3 we use `botor`.
 
 The `botor` package provides an alternative to `Rs3tools`. It's maintained by the wider R community and contains a larger range of functionality. Reading from S3 using `botor` can be done using this command:
 
 ```{r, results="hide"}
-offenders <- botor::s3_read("s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv", read_csv)
+offenders <- botor::s3_read(
+  uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv",
+  fun = readr::read_csv)
 ```
 
-More information on `Rs3tools` and `botor` can be found in the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
+More information on `botor` can be found on the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
 
 
 ## Inspecting the dataset
@@ -388,8 +412,6 @@ We can keep only those variables we want from the `offenders` dataset using the 
 ?dplyr::select
 ```
 
-The use of double colons enables you to specify the package you are referring to before calling the function, hence avoiding using the wrong function if two functions have the same name and are from different packages. If the package isn't specified by using the double-colon notation then R will use the function from your most recently loaded package and will warn you when you load a package if there is some overlap.
-
 So, if we want to create a new dataset called offenders_anonymous which only includes the variables representing date of birth, weight and number of previous convictions from the dataset offenders:
 
 ```{r results="hide"}
@@ -405,7 +427,7 @@ offenders_anonymous <- offenders %>%
   dplyr::select(BIRTH_DATE, WEIGHT, PREV_CONVICTIONS)
 ```
 
-Here the offenders data are "piped" like water into the select command using the pipe symbol `%>%`. This is interpreted by R as the first argument of the select command so the offenders dataset is not specified within the select command. The pipe operator makes code more readable by allowing us to chain together multiple functions and means you don't have to either create a new object each time you run a command or use nested functions (functions that are within other functions).  
+This is part of the `magrittr` package, which we loaded earlier. Here the offenders data are "piped" like water into the select command using the pipe symbol `%>%`. This is interpreted by R as the first argument of the select command so the offenders dataset is not specified within the select command. The pipe operator makes code more readable by allowing us to chain together multiple functions and means you don't have to either create a new object each time you run a command or use nested functions (functions that are within other functions).  
 
 Let's say that now we want the offenders_anonymous dataset to be the same as the dataset offenders but without the names and addresses:
 
@@ -430,7 +452,8 @@ So if we want the mean number of previous convictions with breakdown by REGION a
 ```{r results="hide"}
 regional_gender_average <- offenders %>% 
   dplyr::group_by(REGION, GENDER) %>%
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS))
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   .groups = 'keep')
 ```
 
 Here R takes the offenders dataset, then (the pipe operator can be read as "then") groups it first by `REGION` and then by `GENDER` and then outputs the mean number of previous convictions by `REGION` and `GENDER`. The mean number of previous convictions variable created we've decided to call `Ave`. The results are saved into a new dataset called `regional_gender_average`.
@@ -442,7 +465,9 @@ If we want to add a new variable that we decide to call `Count` that provides th
 ```{r results="hide"}
 regional_gender_average <- offenders %>% 
   dplyr::group_by(REGION, GENDER) %>%
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS), Count=n())
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   Count = dplyr::n(),
+                   groups = 'keep')
 ```
 
 The `count()` function can also be used to calculate the counts by `REGION` and `GENDER` in one line, replacing the `group_by()` and `summarise()` above:
@@ -456,7 +481,7 @@ It is important to pay attention to the way in which the data have been grouped.
 
 ```{r results="hide"}
 regional_gender_average %>% 
-  dplyr::summarise(Count = n())
+  dplyr::summarise(Count = dplyr::n())
 ```
 
 But if we want to count all the rows in the `regional_gender_average` dataset with the grouping removed we add in the `ungroup()` function:
@@ -464,7 +489,7 @@ But if we want to count all the rows in the `regional_gender_average` dataset wi
 ```{r results="hide"}
 regional_gender_average %>% 
  dplyr::ungroup() %>% 
- dplyr::summarise(Count = n())
+ dplyr::summarise(Count = dlyr::n())
 ```
 The `summarise(Count = n())` above can also be replaced with `tally()` to count the number of rows in a dataset.
 
@@ -477,9 +502,8 @@ Let's first take a look at the different possible values of the `SENTENCE` varia
 ```{r results="hide"}
 offenders %>% 
   dplyr::group_by(SENTENCE) %>% 
-  dplyr::summarise(Count = n())
+  dplyr::summarise(Count = dplyr::n())
 ```
-
 Or using the `count()` function:
 
 ```{r results="hide"}
@@ -493,7 +517,8 @@ To filter we just specify the data that we want to filter (`offenders`) and the 
 crt_order_average <- offenders %>% 
   dplyr::filter(SENTENCE == "Court_order" & AGE > 50) %>% 
   dplyr::group_by(REGION, GENDER) %>% 
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS))
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   .groups = 'keep')
 ```
 
 ## Rename
@@ -539,7 +564,10 @@ Another useful function found in the `dplyr` package is `if_else()`, which works
 
 ```{r results="hide"}
 offenders <- offenders %>% 
-  dplyr::mutate(weight_under_170 = if_else(WEIGHT < 170, 1, 0))
+  dplyr::mutate(weight_under_170 = dplyr::if_else(
+    condition = WEIGHT < 170,
+    true = 1,
+    false = 0))
 ```
 
 ## Exercises
@@ -554,11 +582,7 @@ offenders <- offenders %>%
 
 As you might have noticed, `BIRTH_DATE` in the `offenders` dataset currently has class character. To be able to manipulate dates in date format, we first need to convert the data to have class date.
 
-In this section, we are going to use a package from `tidyverse` called `lubridate` to enable R to recognize and manipulate dates. First, we need to load the package:
-
-```{r results=FALSE, warning=FALSE, comment=FALSE}
-library(lubridate)
-```
+In this section, we are going to use a package from `tidyverse` called `lubridate` to enable R to recognize and manipulate dates.
 
 Class date involves dates being represented in R as the number of days since 1970-01-01, with negative values for earlier dates. The format is year (4 digits) - month (2 digits) - day (2 digits). You can see this if we ask R for today's date:
 ```{r results="hide"}
@@ -570,7 +594,7 @@ If you have a read of the help file, you'll see `lubridate` has a number of func
 We can therefore make a new date variable (called `DoB_formatted`) with class date as follows, and then check the class of the new column:
 
 ```{r results="hide"}
-offenders<- offenders %>% 
+offenders <- offenders %>% 
   dplyr::mutate(DoB_formatted = lubridate::mdy(BIRTH_DATE))
 
 class(offenders$DoB_formatted)
@@ -595,7 +619,10 @@ offenders <- offenders %>%
   dplyr::mutate(month = lubridate::month(DoB_formatted))
 
 offenders <- offenders %>%
-  dplyr::mutate(weekday = lubridate::wday(DoB_formatted, label=TRUE, abbr=FALSE))
+  dplyr::mutate(weekday = lubridate::wday(
+    x = DoB_formatted,
+    label = TRUE,
+    abbr = FALSE))
 ```
 
 You can also calculate the number of days since a date. For instance, let's say we want to know the number of days between the date of birth and 1 Jan 2000:
@@ -620,7 +647,9 @@ There are `dplyr` functions `left_join()`, `right_join()`, `inner_join()`, `full
 Let's import a new dataset which contains information on whether the offenders faced trial. Use either of the following commands, depending on whether you're using the Analytical Platform version of RStudio or a local version:
 
 ```{r results="hide"}
-offenders_trial <- botor::s3_read("s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv", read_csv)
+offenders_trial <- botor::s3_read(
+  uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv",
+  fun = readr::read_csv)
 ```
 
 ```{r eval=FALSE, results="hide"}
@@ -630,19 +659,25 @@ offenders_trial <- readr::read_csv("Offenders_Chicago_Police_Dept_Trial.csv")
 We merge the datasets with offenders using the combination of fields that together form a unique identifier. But first we need to rename `DoB` to `BIRTH_DATE` in the `offenders_trial` dataset:
 
 ```{r results="hide"}
-offenders_trial <- offenders_trial %>% dplyr::rename(BIRTH_DATE=DoB) 
+offenders_trial <- offenders_trial %>% dplyr::rename(BIRTH_DATE = DoB) 
 ```
 
 Now the variables that together form a unique identifier have the same names, we can do the merge:
 
 ```{r results="hide"}
-offenders_merge <- dplyr::inner_join(offenders, offenders_trial, by=c("LAST", "BIRTH_DATE")) 
+offenders_merge <- dplyr::inner_join(
+  x = offenders,
+  y = offenders_trial,
+  by = c("LAST", "BIRTH_DATE")) 
 ```
 
 Alternatively, instead of renaming the columns we want to join two datasets on that have different names, we can simply provide both column names to the `by` argument of `inner_join()`, as below:
 
 ```{r results="hide"}
-offenders_merge <- dplyr::inner_join(offenders, offenders_trial, by=c("LAST", "BIRTH_DATE" = "DoB")) 
+offenders_merge <- dplyr::inner_join(
+  x = offenders, 
+  y = offenders_trial,
+  by = c("LAST", "BIRTH_DATE" = "DoB")) 
 ```
 
 For more information about the different sorts of joins and other data transformation functions see the 'Data Transformation Cheat Sheet' at: https://www.rstudio.com/resources/cheatsheets/  
@@ -680,7 +715,7 @@ We can look at the `HEIGHT` variable as previously:
 ```{r results="hide"}
 height_table <- offenders %>% 
   dplyr::group_by(HEIGHT) %>% 
-  dplyr::summarise(Count=n())
+  dplyr::summarise(Count= dplyr::n())
 ```
 
 Then we can view the `height_table` we've made which will include the number of missing values the height variable contains:

--- a/Intro_markdown.html
+++ b/Intro_markdown.html
@@ -1705,7 +1705,7 @@ RStudio will be relative to this folder.</p>
 directory):</p>
 <pre class="r"><code>getwd()</code></pre>
 <p>If you want to change the working directory to a specific
-repository/folder - in this case <code>IntroRTraining</code>, you can
+repository/folder - in this case <code>IntroRTraining</code> - you can
 use the <code>setwd()</code> command as follows:</p>
 <pre class="r"><code>setwd(&quot;~/IntroRTraining&quot;)</code></pre>
 <p>Alternatively, you can set your working directory following the steps
@@ -1854,7 +1854,7 @@ package</h4>
 MoJ and has the advantage of being R-native, resulting in it being
 quicker to install than <code>botor</code> (which requires a Python
 environment). Here’s how it can be installed:</p>
-<pre class="r"><code>install.packages(&quot;moj-analytical-services/Rs3tools&quot;)</code></pre>
+<pre class="r"><code>renv::install(&quot;moj-analytical-services/Rs3tools&quot;)</code></pre>
 <p>And here’s how to use <code>Rs3tools</code> to read in the
 <code>offenders</code> dataset that we’ll be using in this session from
 the ‘alpha-r-training’ S3 bucket:</p>
@@ -1871,6 +1871,8 @@ contains a larger range of functionality. Reading from S3 using
 <pre class="r"><code>offenders &lt;- botor::s3_read(
   uri = &quot;s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv&quot;,
   fun = readr::read_csv)</code></pre>
+<p>Here we are passing another function to <code>botor::s3_read</code>
+which it uses to read the data from the uri.</p>
 <p>More information on <code>Rs3tools</code> and <code>botor</code> can
 be found in the <a href="https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio">AP
 guidance</a>.</p>
@@ -2274,12 +2276,15 @@ values and exporting</h1>
 <code>anti_join()</code> which can merge data sets, provided you have
 some common fields to match on. This is similar to SQL.</p>
 <p>Let’s import a new dataset which contains information on whether the
-offenders faced trial. Use either of the following commands, depending
-on whether you’re using the Analytical Platform version of RStudio or a
-local version:</p>
+offenders faced trial. Use one of the following commands:</p>
+<p>Using Rs3tools</p>
+<pre class="r"><code>offenders_trial &lt;-  Rs3tools::s3_path_to_full_df(
+  s3_path = &quot;s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv&quot;)</code></pre>
+<p>Using botor:</p>
 <pre class="r"><code>offenders_trial &lt;- botor::s3_read(
   uri = &quot;s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv&quot;,
   fun = readr::read_csv)</code></pre>
+<p>Using local file read:</p>
 <pre class="r"><code>offenders_trial &lt;- readr::read_csv(&quot;Offenders_Chicago_Police_Dept_Trial.csv&quot;)</code></pre>
 <p>We merge the datasets with offenders using the combination of fields
 that together form a unique identifier. But first we need to rename

--- a/Intro_markdown.html
+++ b/Intro_markdown.html
@@ -1799,8 +1799,9 @@ warned about any overlaps when you load a package.</p>
 the operator <code>%&gt;%</code> (pipe) without specifying the package
 name, because it would be bad for our readability. So we do want to load
 the package <code>magrittr</code>.</p>
-<p>Please load <code>magrittr</code> by one of the methods described
-above (which do you you think would be best practice overall)?</p>
+<p>If you haven’t already, load <code>magrittr</code> by one of the
+methods described above (which do you you think would be best practice
+overall)?</p>
 <p>To know more about a package, it is always useful to read the
 associated documentation:</p>
 <pre class="r"><code>?dplyr</code></pre>
@@ -2094,7 +2095,7 @@ grouped by the first grouping variable, which in this case is
 we add in the <code>ungroup()</code> function:</p>
 <pre class="r"><code>regional_gender_average %&gt;% 
  dplyr::ungroup() %&gt;% 
- dplyr::summarise(Count = dlyr::n())</code></pre>
+ dplyr::summarise(Count = dplyr::n())</code></pre>
 <p>The <code>summarise(Count = n())</code> above can also be replaced
 with <code>tally()</code> to count the number of rows in a dataset.</p>
 </div>

--- a/Intro_markdown.html
+++ b/Intro_markdown.html
@@ -1705,8 +1705,8 @@ RStudio will be relative to this folder.</p>
 directory):</p>
 <pre class="r"><code>getwd()</code></pre>
 <p>If you want to change the working directory to a specific
-repository/folder, you can use the <code>setwd()</code> command as
-follows:</p>
+repository/folder - in this case <code>IntroRTraining</code>, you can
+use the <code>setwd()</code> command as follows:</p>
 <pre class="r"><code>setwd(&quot;~/IntroRTraining&quot;)</code></pre>
 <p>Alternatively, you can set your working directory following the steps
 below:</p>
@@ -1756,7 +1756,7 @@ use the package <code>renv</code> to manage your packages.</p>
 <p>To synchronise your working R environment with this course’s repo,
 run</p>
 <pre class="r"><code>renv::restore()</code></pre>
-<p>If you have no installed <code>renv</code> yet, you can do this
+<p>If you have not installed <code>renv</code> yet, you can do this
 with</p>
 <pre class="r"><code>install.packages(&#39;renv&#39;)</code></pre>
 <p>If prompted to update, enter Y for Yes. This should now update your
@@ -1784,15 +1784,17 @@ being called, e.g.</p>
 <code>lubridate</code> package. We’re passing to it the current
 date.</p>
 <p>Functions that are ‘base’ R, or part of a core package such as the
-<code>stats</code> package, which we use below, do not require.</p>
+<code>stats</code> package, which we use below, do not require the
+package/library name to precede the function name when the function is
+called.</p>
 <p>Although including the library call makes the code longer, it also
 makes it more readable, as anyone who is unfamiliar with the code can
 see very easily where functions are being called, and which packages are
 being used. It also avoids the wrong function being called if two
 functions have the same name and are from different packages. If the
 package isn’t specified by using the double-colon notation then R will
-use the function from your most recently loaded package and will warn
-you when you load a package if there is some overlap.</p>
+use the function from your most recently loaded package. You will be
+warned about any overlaps when you load a package.</p>
 <p>However there are exceptions to this. In particular, we want to use
 the operator <code>%&gt;%</code> (pipe) without specifying the package
 name, because it would be bad for our readability. So we do want to load
@@ -1843,7 +1845,25 @@ the Analytical Platform cloud storage (Amazon S3)</h3>
 <p>Data that has been approved for storage on the Analytical Platform is
 generally stored in a data source (referred to as a ‘bucket’) on Amazon
 S3, which is the cloud storage solution used by the Analytical Platform.
-To import data from S3 we use <code>botor</code>.</p>
+There are two options for packages that can be used to import data from
+S3: <code>Rs3tools</code> and <code>botor</code>.</p>
+<div id="importing-data-using-the-rs3tools-package" class="section level4 unnumbered">
+<h4 class="unnumbered">Importing data using the <code>Rs3tools</code>
+package</h4>
+<p>The <code>Rs3tools</code> package is maintained by other analysts in
+MoJ and has the advantage of being R-native, resulting in it being
+quicker to install than <code>botor</code> (which requires a Python
+environment). Here’s how it can be installed:</p>
+<pre class="r"><code>install.packages(&quot;moj-analytical-services/Rs3tools&quot;)</code></pre>
+<p>And here’s how to use <code>Rs3tools</code> to read in the
+<code>offenders</code> dataset that we’ll be using in this session from
+the ‘alpha-r-training’ S3 bucket:</p>
+<pre class="r"><code>offenders &lt;- Rs3tools::s3_path_to_full_df(
+  s3_path = &quot;alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv&quot;)</code></pre>
+</div>
+<div id="importing-data-using-the-botor-package" class="section level4 unnumbered">
+<h4 class="unnumbered">Importing data using the <code>botor</code>
+package</h4>
 <p>The <code>botor</code> package provides an alternative to
 <code>Rs3tools</code>. It’s maintained by the wider R community and
 contains a larger range of functionality. Reading from S3 using
@@ -1851,8 +1871,10 @@ contains a larger range of functionality. Reading from S3 using
 <pre class="r"><code>offenders &lt;- botor::s3_read(
   uri = &quot;s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv&quot;,
   fun = readr::read_csv)</code></pre>
-<p>More information on <code>botor</code> can be found on the <a href="https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio">AP
+<p>More information on <code>Rs3tools</code> and <code>botor</code> can
+be found in the <a href="https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio">AP
 guidance</a>.</p>
+</div>
 </div>
 </div>
 <div id="inspecting-the-dataset" class="section level2" number="2.4">

--- a/Intro_markdown.html
+++ b/Intro_markdown.html
@@ -1707,7 +1707,7 @@ directory):</p>
 <p>If you want to change the working directory to a specific
 repository/folder, you can use the <code>setwd()</code> command as
 follows:</p>
-<pre class="r"><code>setwd(&quot;~/folder_name&quot;)</code></pre>
+<pre class="r"><code>setwd(&quot;~/IntroRTraining&quot;)</code></pre>
 <p>Alternatively, you can set your working directory following the steps
 below:</p>
 <ol style="list-style-type: decimal">
@@ -1749,26 +1749,56 @@ recognize is that just as there are many ways of getting from Victoria
 Station to 102 Petty France, there are many ways of doing the same thing
 in R. Some ways are (computationally) faster, some are simpler to
 program, and some may be more conducive to your taste.</p>
-<p>Packages extend R’s functionality enormously and are a key factor in
-making R so popular. For instance, to install the <code>tidyverse</code>
-suite of packages in R, which we recommend you use for data manipulation
-and analysis, use the Install button from the Packages tab in
-Rstudio.</p>
-<p>This runs the following command:</p>
-<pre class="r"><code>install.packages(&quot;tidyverse&quot;)</code></pre>
-<p>Note that if you are using R on the Analytical Platform the tidyverse
-package may already be installed, hence the above step can be
-skipped.</p>
-<p>Once a package is installed, you should be able to see it in the
-packages tab. If you want to use it, you can load it by ticking the
-appropriate box in the packages window. You can also load packages using
-the library command, which you can put inside your script, so they will
-automatically load when you run it:</p>
-<pre class="r"><code>library(&quot;tidyverse&quot;)</code></pre>
+<p>Packages (also known as libraries) extend R’s functionality
+enormously and are a key factor in making R so popular.</p>
+<p>Assuming that you are working with R on the AP, you are encouraged to
+use the package <code>renv</code> to manage your packages.</p>
+<p>To synchronise your working R environment with this course’s repo,
+run</p>
+<pre class="r"><code>renv::restore()</code></pre>
+<p>If you have no installed <code>renv</code> yet, you can do this
+with</p>
+<pre class="r"><code>install.packages(&#39;renv&#39;)</code></pre>
+<p>If prompted to update, enter Y for Yes. This should now update your
+project environment.</p>
+<p>This is the command to install/update a package using
+<code>renv</code>:</p>
+<pre class="r"><code>renv::install(&#39;tidyverse&#39;)</code></pre>
+<p>Run this, and the tidyverse package (actually a suite of packages)
+should update to a more recent version.</p>
 <p>The package suite <code>tidyverse</code> contains many useful
 packages such as <code>dplyr</code> which is a particularly useful
 package for manipulating and processing data. Many of the functions in
 the rest of this introductory training are from this package.</p>
+<p>There are different ways of using packages It is possible to load
+them with library calls, usually found at the start of scripts, e.g.</p>
+<pre class="r"><code>library(&quot;magrittr&quot;)</code></pre>
+<p>You can also load packages via the GUI. You should be able to see
+them in the packages tab. You can load them by ticking the appropriate
+box in the packages window.</p>
+<p>However, for the most part it is considered best practice to not rely
+on having libraries loaded, but instead to specify them when they are
+being called, e.g.</p>
+<pre class="r"><code>lubridate::days_in_month(Sys.Date())</code></pre>
+<p>Here we’re using function <code>days_in_month()</code> from the
+<code>lubridate</code> package. We’re passing to it the current
+date.</p>
+<p>Functions that are ‘base’ R, or part of a core package such as the
+<code>stats</code> package, which we use below, do not require.</p>
+<p>Although including the library call makes the code longer, it also
+makes it more readable, as anyone who is unfamiliar with the code can
+see very easily where functions are being called, and which packages are
+being used. It also avoids the wrong function being called if two
+functions have the same name and are from different packages. If the
+package isn’t specified by using the double-colon notation then R will
+use the function from your most recently loaded package and will warn
+you when you load a package if there is some overlap.</p>
+<p>However there are exceptions to this. In particular, we want to use
+the operator <code>%&gt;%</code> (pipe) without specifying the package
+name, because it would be bad for our readability. So we do want to load
+the package <code>magrittr</code>.</p>
+<p>Please load <code>magrittr</code> by one of the methods described
+above (which do you you think would be best practice overall)?</p>
 <p>To know more about a package, it is always useful to read the
 associated documentation:</p>
 <pre class="r"><code>?dplyr</code></pre>
@@ -1813,33 +1843,16 @@ the Analytical Platform cloud storage (Amazon S3)</h3>
 <p>Data that has been approved for storage on the Analytical Platform is
 generally stored in a data source (referred to as a ‘bucket’) on Amazon
 S3, which is the cloud storage solution used by the Analytical Platform.
-There are two options for packages that can be used to import data from
-S3: <code>Rs3tools</code> and <code>botor</code>.</p>
-<div id="importing-data-using-the-rs3tools-package" class="section level4 unnumbered">
-<h4 class="unnumbered">Importing data using the <code>Rs3tools</code>
-package</h4>
-<p>The <code>Rs3tools</code> package is maintained by other analysts in
-MoJ and has the advantage of being R-native, resulting in it being
-quicker to install than <code>botor</code> (which requires a Python
-environment). Here’s how it can be installed:</p>
-<pre class="r"><code>install.packages(&quot;moj-analytical-services/Rs3tools&quot;)</code></pre>
-<p>And here’s how to use <code>Rs3tools</code> to read in the
-<code>offenders</code> dataset that we’ll be using in this session from
-the ‘alpha-r-training’ S3 bucket:</p>
-<pre class="r"><code>offenders &lt;- Rs3tools::s3_path_to_full_df(&quot;alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv&quot;)</code></pre>
-</div>
-<div id="importing-data-using-the-botor-package" class="section level4 unnumbered">
-<h4 class="unnumbered">Importing data using the <code>botor</code>
-package</h4>
+To import data from S3 we use <code>botor</code>.</p>
 <p>The <code>botor</code> package provides an alternative to
 <code>Rs3tools</code>. It’s maintained by the wider R community and
 contains a larger range of functionality. Reading from S3 using
 <code>botor</code> can be done using this command:</p>
-<pre class="r"><code>offenders &lt;- botor::s3_read(&quot;s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv&quot;, read_csv)</code></pre>
-<p>More information on <code>Rs3tools</code> and <code>botor</code> can
-be found in the <a href="https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio">AP
+<pre class="r"><code>offenders &lt;- botor::s3_read(
+  uri = &quot;s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv&quot;,
+  fun = readr::read_csv)</code></pre>
+<p>More information on <code>botor</code> can be found on the <a href="https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio">AP
 guidance</a>.</p>
-</div>
 </div>
 </div>
 <div id="inspecting-the-dataset" class="section level2" number="2.4">
@@ -1969,13 +1982,6 @@ and output its levels.</li>
 <code>offenders</code> dataset using the select command from the
 <code>dplyr</code> package.</p>
 <pre class="r"><code>?dplyr::select</code></pre>
-<p>The use of double colons enables you to specify the package you are
-referring to before calling the function, hence avoiding using the wrong
-function if two functions have the same name and are from different
-packages. If the package isn’t specified by using the double-colon
-notation then R will use the function from your most recently loaded
-package and will warn you when you load a package if there is some
-overlap.</p>
 <p>So, if we want to create a new dataset called offenders_anonymous
 which only includes the variables representing date of birth, weight and
 number of previous convictions from the dataset offenders:</p>
@@ -1987,7 +1993,8 @@ keep.</p>
 (<code>%&gt;%</code>) operator:</p>
 <pre class="r"><code>offenders_anonymous &lt;- offenders %&gt;% 
   dplyr::select(BIRTH_DATE, WEIGHT, PREV_CONVICTIONS)</code></pre>
-<p>Here the offenders data are “piped” like water into the select
+<p>This is part of the <code>magrittr</code> package, which we loaded
+earlier. Here the offenders data are “piped” like water into the select
 command using the pipe symbol <code>%&gt;%</code>. This is interpreted
 by R as the first argument of the select command so the offenders
 dataset is not specified within the select command. The pipe operator
@@ -2023,7 +2030,8 @@ commands, and in a manner which makes the code easy to read.</p>
 by REGION and GENDER:</p>
 <pre class="r"><code>regional_gender_average &lt;- offenders %&gt;% 
   dplyr::group_by(REGION, GENDER) %&gt;%
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS))</code></pre>
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   .groups = &#39;keep&#39;)</code></pre>
 <p>Here R takes the offenders dataset, then (the pipe operator can be
 read as “then”) groups it first by <code>REGION</code> and then by
 <code>GENDER</code> and then outputs the mean number of previous
@@ -2040,7 +2048,9 @@ number of previous convictions variable created we’ve decided to call
 <code>GENDER</code> we can rerun as follows using the pipe operator:</p>
 <pre class="r"><code>regional_gender_average &lt;- offenders %&gt;% 
   dplyr::group_by(REGION, GENDER) %&gt;%
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS), Count=n())</code></pre>
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   Count = dplyr::n(),
+                   groups = &#39;keep&#39;)</code></pre>
 <p>The <code>count()</code> function can also be used to calculate the
 counts by <code>REGION</code> and <code>GENDER</code> in one line,
 replacing the <code>group_by()</code> and <code>summarise()</code>
@@ -2054,13 +2064,13 @@ run it through <code>summarise()</code> as is, then the result will be
 grouped by the first grouping variable, which in this case is
 <code>REGION</code>:</p>
 <pre class="r"><code>regional_gender_average %&gt;% 
-  dplyr::summarise(Count = n())</code></pre>
+  dplyr::summarise(Count = dplyr::n())</code></pre>
 <p>But if we want to count all the rows in the
 <code>regional_gender_average</code> dataset with the grouping removed
 we add in the <code>ungroup()</code> function:</p>
 <pre class="r"><code>regional_gender_average %&gt;% 
  dplyr::ungroup() %&gt;% 
- dplyr::summarise(Count = n())</code></pre>
+ dplyr::summarise(Count = dlyr::n())</code></pre>
 <p>The <code>summarise(Count = n())</code> above can also be replaced
 with <code>tally()</code> to count the number of rows in a dataset.</p>
 </div>
@@ -2074,7 +2084,7 @@ observations, a good function to use is <code>filter()</code> from the
 <code>group_by()</code>/<code>summarise()</code> combination.</p>
 <pre class="r"><code>offenders %&gt;% 
   dplyr::group_by(SENTENCE) %&gt;% 
-  dplyr::summarise(Count = n())</code></pre>
+  dplyr::summarise(Count = dplyr::n())</code></pre>
 <p>Or using the <code>count()</code> function:</p>
 <pre class="r"><code>offenders %&gt;% 
   dplyr::count(SENTENCE)</code></pre>
@@ -2087,7 +2097,8 @@ previous convictions with breakdown by <code>REGION</code> and
 <pre class="r"><code>crt_order_average &lt;- offenders %&gt;% 
   dplyr::filter(SENTENCE == &quot;Court_order&quot; &amp; AGE &gt; 50) %&gt;% 
   dplyr::group_by(REGION, GENDER) %&gt;% 
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS))</code></pre>
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   .groups = &#39;keep&#39;)</code></pre>
 </div>
 <div id="rename" class="section level2" number="3.4">
 <h2><span class="header-section-number">3.4</span> Rename</h2>
@@ -2134,7 +2145,10 @@ used together with it to add a variable in to the <code>offenders</code>
 dataset which is 1 if they are under 170lbs and 0 if they are over
 170lbs.</p>
 <pre class="r"><code>offenders &lt;- offenders %&gt;% 
-  dplyr::mutate(weight_under_170 = if_else(WEIGHT &lt; 170, 1, 0))</code></pre>
+  dplyr::mutate(weight_under_170 = dplyr::if_else(
+    condition = WEIGHT &lt; 170,
+    true = 1,
+    false = 0))</code></pre>
 </div>
 <div id="exercises-2" class="section level2" number="3.7">
 <h2><span class="header-section-number">3.7</span> Exercises</h2>
@@ -2166,8 +2180,7 @@ to manipulate dates in date format, we first need to convert the data to
 have class date.</p>
 <p>In this section, we are going to use a package from
 <code>tidyverse</code> called <code>lubridate</code> to enable R to
-recognize and manipulate dates. First, we need to load the package:</p>
-<pre class="r"><code>library(lubridate)</code></pre>
+recognize and manipulate dates.</p>
 <p>Class date involves dates being represented in R as the number of
 days since 1970-01-01, with negative values for earlier dates. The
 format is year (4 digits) - month (2 digits) - day (2 digits). You can
@@ -2181,7 +2194,7 @@ the character string to be parsed.</p>
 <p>We can therefore make a new date variable (called
 <code>DoB_formatted</code>) with class date as follows, and then check
 the class of the new column:</p>
-<pre class="r"><code>offenders&lt;- offenders %&gt;% 
+<pre class="r"><code>offenders &lt;- offenders %&gt;% 
   dplyr::mutate(DoB_formatted = lubridate::mdy(BIRTH_DATE))
 
 class(offenders$DoB_formatted)</code></pre>
@@ -2203,7 +2216,10 @@ offenders &lt;- offenders %&gt;%
   dplyr::mutate(month = lubridate::month(DoB_formatted))
 
 offenders &lt;- offenders %&gt;%
-  dplyr::mutate(weekday = lubridate::wday(DoB_formatted, label=TRUE, abbr=FALSE))</code></pre>
+  dplyr::mutate(weekday = lubridate::wday(
+    x = DoB_formatted,
+    label = TRUE,
+    abbr = FALSE))</code></pre>
 <p>You can also calculate the number of days since a date. For instance,
 let’s say we want to know the number of days between the date of birth
 and 1 Jan 2000:</p>
@@ -2239,21 +2255,29 @@ some common fields to match on. This is similar to SQL.</p>
 offenders faced trial. Use either of the following commands, depending
 on whether you’re using the Analytical Platform version of RStudio or a
 local version:</p>
-<pre class="r"><code>offenders_trial &lt;- botor::s3_read(&quot;s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv&quot;, read_csv)</code></pre>
+<pre class="r"><code>offenders_trial &lt;- botor::s3_read(
+  uri = &quot;s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv&quot;,
+  fun = readr::read_csv)</code></pre>
 <pre class="r"><code>offenders_trial &lt;- readr::read_csv(&quot;Offenders_Chicago_Police_Dept_Trial.csv&quot;)</code></pre>
 <p>We merge the datasets with offenders using the combination of fields
 that together form a unique identifier. But first we need to rename
 <code>DoB</code> to <code>BIRTH_DATE</code> in the
 <code>offenders_trial</code> dataset:</p>
-<pre class="r"><code>offenders_trial &lt;- offenders_trial %&gt;% dplyr::rename(BIRTH_DATE=DoB) </code></pre>
+<pre class="r"><code>offenders_trial &lt;- offenders_trial %&gt;% dplyr::rename(BIRTH_DATE = DoB) </code></pre>
 <p>Now the variables that together form a unique identifier have the
 same names, we can do the merge:</p>
-<pre class="r"><code>offenders_merge &lt;- dplyr::inner_join(offenders, offenders_trial, by=c(&quot;LAST&quot;, &quot;BIRTH_DATE&quot;)) </code></pre>
+<pre class="r"><code>offenders_merge &lt;- dplyr::inner_join(
+  x = offenders,
+  y = offenders_trial,
+  by = c(&quot;LAST&quot;, &quot;BIRTH_DATE&quot;)) </code></pre>
 <p>Alternatively, instead of renaming the columns we want to join two
 datasets on that have different names, we can simply provide both column
 names to the <code>by</code> argument of <code>inner_join()</code>, as
 below:</p>
-<pre class="r"><code>offenders_merge &lt;- dplyr::inner_join(offenders, offenders_trial, by=c(&quot;LAST&quot;, &quot;BIRTH_DATE&quot; = &quot;DoB&quot;)) </code></pre>
+<pre class="r"><code>offenders_merge &lt;- dplyr::inner_join(
+  x = offenders, 
+  y = offenders_trial,
+  by = c(&quot;LAST&quot;, &quot;BIRTH_DATE&quot; = &quot;DoB&quot;)) </code></pre>
 <p>For more information about the different sorts of joins and other
 data transformation functions see the ‘Data Transformation Cheat Sheet’
 at: <a href="https://www.rstudio.com/resources/cheatsheets/" class="uri">https://www.rstudio.com/resources/cheatsheets/</a></p>
@@ -2288,7 +2312,7 @@ data functions we’ll use in this section recognize both these types.</p>
 <p>We can look at the <code>HEIGHT</code> variable as previously:</p>
 <pre class="r"><code>height_table &lt;- offenders %&gt;% 
   dplyr::group_by(HEIGHT) %&gt;% 
-  dplyr::summarise(Count=n())</code></pre>
+  dplyr::summarise(Count= dplyr::n())</code></pre>
 <p>Then we can view the <code>height_table</code> we’ve made which will
 include the number of missing values the height variable contains:</p>
 <pre class="r"><code>View(height_table)</code></pre>

--- a/Intro_markdown.md
+++ b/Intro_markdown.md
@@ -151,7 +151,7 @@ You can check what the working directory currently is by using the `getwd()` com
 getwd()
 ```
 
-If you want to change the working directory to a specific repository/folder - in this case `IntroRTraining`, you can use the `setwd()` command as follows:
+If you want to change the working directory to a specific repository/folder - in this case `IntroRTraining` - you can use the `setwd()` command as follows:
 
 
 ```r
@@ -283,7 +283,7 @@ The `Rs3tools` package is maintained by other analysts in MoJ and has the advant
 
 
 ```r
-install.packages("moj-analytical-services/Rs3tools")
+renv::install("moj-analytical-services/Rs3tools")
 ```
 
 And here's how to use `Rs3tools` to read in the `offenders` dataset that we'll be using in this session from the 'alpha-r-training' S3 bucket:
@@ -304,6 +304,10 @@ offenders <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv",
   fun = readr::read_csv)
 ```
+
+Here we are passing another function to `botor::s3_read` which it uses to read the data
+from the uri.
+
 More information on `Rs3tools` and `botor` can be found in the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
 
 ## Inspecting the dataset
@@ -701,7 +705,17 @@ offenders <- offenders %>%
 
 There are `dplyr` functions `left_join()`, `right_join()`, `inner_join()`, `full_join()`, `semi_join()` and `anti_join()` which can merge data sets, provided you have some common fields to match on. This is similar to SQL.
 
-Let's import a new dataset which contains information on whether the offenders faced trial. Use either of the following commands, depending on whether you're using the Analytical Platform version of RStudio or a local version:
+Let's import a new dataset which contains information on whether the offenders faced trial. Use one of the following commands:
+
+Using Rs3tools
+
+
+```r
+offenders_trial <-  Rs3tools::s3_path_to_full_df(
+  s3_path = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv")
+```
+
+Using botor:
 
 
 ```r
@@ -709,6 +723,8 @@ offenders_trial <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv",
   fun = readr::read_csv)
 ```
+
+Using local file read:
 
 
 ```r

--- a/Intro_markdown.md
+++ b/Intro_markdown.md
@@ -155,7 +155,7 @@ If you want to change the working directory to a specific repository/folder, you
 
 
 ```r
-setwd("~/folder_name")
+setwd("~/IntroRTraining")
 ```
 
 Alternatively, you can set your working directory following the steps below:
@@ -180,25 +180,64 @@ Your new directory will be automatically set as the working directory. If you ha
 
 A lot of pre-programmed routines are included in R, and you can add a lot more through packages. One characteristic that's important to recognize is that just as there are many ways of getting from Victoria Station to 102 Petty France, there are many ways of doing the same thing in R. Some ways are (computationally) faster, some are simpler to program, and some may be more conducive to your taste.  
 
-Packages extend R's functionality enormously and are a key factor in making R so popular. For instance, to install the `tidyverse` suite of packages in R, which we recommend you use for data manipulation and analysis, use the Install button from the Packages tab in Rstudio. 
+Packages (also known as libraries) extend R's functionality enormously and are a key factor in making R so popular.
 
-This runs the following command:
+Assuming that you are working with R on the AP, you are encouraged to use the
+package `renv` to manage your packages.
 
-
-```r
-install.packages("tidyverse")
-```
-
-Note that if you are using R on the Analytical Platform the tidyverse package may already be installed, hence the above step can be skipped. 
-
-Once a package is installed, you should be able to see it in the packages tab. If you want to use it, you can load it by ticking the appropriate box in the packages window. You can also load packages using the library command, which you can put inside your script, so they will automatically load when you run it:
+To synchronise your working R environment with this course's repo, run
 
 
 ```r
-library("tidyverse")
+renv::restore()
 ```
+If you have no installed `renv` yet, you can do this with
+
+
+```r
+install.packages('renv')
+```
+
+If prompted to update, enter Y for Yes. This should now update your project 
+environment.
+
+This is the command to install/update a package using `renv`:
+
+
+```r
+renv::install('tidyverse')
+```
+
+Run this, and the tidyverse package (actually a suite of packages) should update
+to a more recent version.
 
 The package suite `tidyverse` contains many useful packages such as `dplyr` which is a particularly useful package for manipulating and processing data. Many of the functions in the rest of this introductory training are from this package.
+
+There are different ways of using packages  It is possible to load them with library calls, usually found at the start of scripts, e.g.
+
+
+```r
+library("magrittr")
+```
+
+You can also load packages via the GUI. You should be able to see them in the packages tab. You can load them by ticking the appropriate box in the packages window.
+
+However, for the most part it is considered best practice to not rely on having libraries loaded, but instead to specify them when they are being called, e.g.
+
+
+```r
+lubridate::days_in_month(Sys.Date())
+```
+
+Here we're using function `days_in_month()` from the `lubridate` package. We're passing to it the current date.
+
+Functions that are 'base' R, or part of a core package such as the `stats` package, which we use below, do not require.
+
+Although including the library call makes the code longer, it also makes it more readable, as anyone who is unfamiliar with the code can see very easily where functions are being called, and which packages are being used. It also avoids the wrong function being called if two functions have the same name and are from different packages. If the package isn't specified by using the double-colon notation then R will use the function from your most recently loaded package and will warn you when you load a package if there is some overlap.
+
+However there are exceptions to this. In particular, we want to use the operator `%>%` (pipe) without specifying the package name, because it would be bad for our readability. So we do want to load the package `magrittr`.
+
+Please load `magrittr` by one of the methods described above (which do you you think would be best practice overall)?
 
 To know more about a package, it is always useful to read the associated documentation:
 
@@ -206,6 +245,8 @@ To know more about a package, it is always useful to read the associated documen
 ```r
 ?dplyr
 ```
+
+
 
 ## Importing data
 
@@ -235,34 +276,18 @@ There are other commands and various packages that can be used to import dataset
 
 ### Importing data from the Analytical Platform cloud storage (Amazon S3)
 
-Data that has been approved for storage on the Analytical Platform is generally stored in a data source (referred to as a 'bucket') on Amazon S3, which is the cloud storage solution used by the Analytical Platform. There are two options for packages that can be used to import data from S3: `Rs3tools` and `botor`.
-
-#### Importing data using the `Rs3tools` package {-}
-
-The `Rs3tools` package is maintained by other analysts in MoJ and has the advantage of being R-native, resulting in it being quicker to install than `botor` (which requires a Python environment). Here's how it can be installed:
-
-
-```r
-install.packages("moj-analytical-services/Rs3tools")
-```
-
-And here's how to use `Rs3tools` to read in the `offenders` dataset that we'll be using in this session from the 'alpha-r-training' S3 bucket:
-
-
-```r
-offenders <- Rs3tools::s3_path_to_full_df("alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv")
-```
-
-#### Importing data using the `botor` package {-}
+Data that has been approved for storage on the Analytical Platform is generally stored in a data source (referred to as a 'bucket') on Amazon S3, which is the cloud storage solution used by the Analytical Platform. To import data from S3 we use `botor`.
 
 The `botor` package provides an alternative to `Rs3tools`. It's maintained by the wider R community and contains a larger range of functionality. Reading from S3 using `botor` can be done using this command:
 
 
 ```r
-offenders <- botor::s3_read("s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv", read_csv)
+offenders <- botor::s3_read(
+  uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv",
+  fun = readr::read_csv)
 ```
 
-More information on `Rs3tools` and `botor` can be found in the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
+More information on `botor` can be found on the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
 
 
 ## Inspecting the dataset
@@ -409,8 +434,6 @@ We can keep only those variables we want from the `offenders` dataset using the 
 ?dplyr::select
 ```
 
-The use of double colons enables you to specify the package you are referring to before calling the function, hence avoiding using the wrong function if two functions have the same name and are from different packages. If the package isn't specified by using the double-colon notation then R will use the function from your most recently loaded package and will warn you when you load a package if there is some overlap.
-
 So, if we want to create a new dataset called offenders_anonymous which only includes the variables representing date of birth, weight and number of previous convictions from the dataset offenders:
 
 
@@ -428,7 +451,7 @@ offenders_anonymous <- offenders %>%
   dplyr::select(BIRTH_DATE, WEIGHT, PREV_CONVICTIONS)
 ```
 
-Here the offenders data are "piped" like water into the select command using the pipe symbol `%>%`. This is interpreted by R as the first argument of the select command so the offenders dataset is not specified within the select command. The pipe operator makes code more readable by allowing us to chain together multiple functions and means you don't have to either create a new object each time you run a command or use nested functions (functions that are within other functions).  
+This is part of the `magrittr` package, which we loaded earlier. Here the offenders data are "piped" like water into the select command using the pipe symbol `%>%`. This is interpreted by R as the first argument of the select command so the offenders dataset is not specified within the select command. The pipe operator makes code more readable by allowing us to chain together multiple functions and means you don't have to either create a new object each time you run a command or use nested functions (functions that are within other functions).  
 
 Let's say that now we want the offenders_anonymous dataset to be the same as the dataset offenders but without the names and addresses:
 
@@ -455,7 +478,8 @@ So if we want the mean number of previous convictions with breakdown by REGION a
 ```r
 regional_gender_average <- offenders %>% 
   dplyr::group_by(REGION, GENDER) %>%
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS))
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   .groups = 'keep')
 ```
 
 Here R takes the offenders dataset, then (the pipe operator can be read as "then") groups it first by `REGION` and then by `GENDER` and then outputs the mean number of previous convictions by `REGION` and `GENDER`. The mean number of previous convictions variable created we've decided to call `Ave`. The results are saved into a new dataset called `regional_gender_average`.
@@ -468,7 +492,9 @@ If we want to add a new variable that we decide to call `Count` that provides th
 ```r
 regional_gender_average <- offenders %>% 
   dplyr::group_by(REGION, GENDER) %>%
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS), Count=n())
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   Count = dplyr::n(),
+                   groups = 'keep')
 ```
 
 The `count()` function can also be used to calculate the counts by `REGION` and `GENDER` in one line, replacing the `group_by()` and `summarise()` above:
@@ -484,7 +510,7 @@ It is important to pay attention to the way in which the data have been grouped.
 
 ```r
 regional_gender_average %>% 
-  dplyr::summarise(Count = n())
+  dplyr::summarise(Count = dplyr::n())
 ```
 
 But if we want to count all the rows in the `regional_gender_average` dataset with the grouping removed we add in the `ungroup()` function:
@@ -493,7 +519,7 @@ But if we want to count all the rows in the `regional_gender_average` dataset wi
 ```r
 regional_gender_average %>% 
  dplyr::ungroup() %>% 
- dplyr::summarise(Count = n())
+ dplyr::summarise(Count = dlyr::n())
 ```
 The `summarise(Count = n())` above can also be replaced with `tally()` to count the number of rows in a dataset.
 
@@ -507,9 +533,8 @@ Let's first take a look at the different possible values of the `SENTENCE` varia
 ```r
 offenders %>% 
   dplyr::group_by(SENTENCE) %>% 
-  dplyr::summarise(Count = n())
+  dplyr::summarise(Count = dplyr::n())
 ```
-
 Or using the `count()` function:
 
 
@@ -525,7 +550,8 @@ To filter we just specify the data that we want to filter (`offenders`) and the 
 crt_order_average <- offenders %>% 
   dplyr::filter(SENTENCE == "Court_order" & AGE > 50) %>% 
   dplyr::group_by(REGION, GENDER) %>% 
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS))
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   .groups = 'keep')
 ```
 
 ## Rename
@@ -576,7 +602,10 @@ Another useful function found in the `dplyr` package is `if_else()`, which works
 
 ```r
 offenders <- offenders %>% 
-  dplyr::mutate(weight_under_170 = if_else(WEIGHT < 170, 1, 0))
+  dplyr::mutate(weight_under_170 = dplyr::if_else(
+    condition = WEIGHT < 170,
+    true = 1,
+    false = 0))
 ```
 
 ## Exercises
@@ -591,12 +620,7 @@ offenders <- offenders %>%
 
 As you might have noticed, `BIRTH_DATE` in the `offenders` dataset currently has class character. To be able to manipulate dates in date format, we first need to convert the data to have class date.
 
-In this section, we are going to use a package from `tidyverse` called `lubridate` to enable R to recognize and manipulate dates. First, we need to load the package:
-
-
-```r
-library(lubridate)
-```
+In this section, we are going to use a package from `tidyverse` called `lubridate` to enable R to recognize and manipulate dates.
 
 Class date involves dates being represented in R as the number of days since 1970-01-01, with negative values for earlier dates. The format is year (4 digits) - month (2 digits) - day (2 digits). You can see this if we ask R for today's date:
 
@@ -610,7 +634,7 @@ We can therefore make a new date variable (called `DoB_formatted`) with class da
 
 
 ```r
-offenders<- offenders %>% 
+offenders <- offenders %>% 
   dplyr::mutate(DoB_formatted = lubridate::mdy(BIRTH_DATE))
 
 class(offenders$DoB_formatted)
@@ -635,7 +659,10 @@ offenders <- offenders %>%
   dplyr::mutate(month = lubridate::month(DoB_formatted))
 
 offenders <- offenders %>%
-  dplyr::mutate(weekday = lubridate::wday(DoB_formatted, label=TRUE, abbr=FALSE))
+  dplyr::mutate(weekday = lubridate::wday(
+    x = DoB_formatted,
+    label = TRUE,
+    abbr = FALSE))
 ```
 
 You can also calculate the number of days since a date. For instance, let's say we want to know the number of days between the date of birth and 1 Jan 2000:
@@ -662,7 +689,9 @@ Let's import a new dataset which contains information on whether the offenders f
 
 
 ```r
-offenders_trial <- botor::s3_read("s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv", read_csv)
+offenders_trial <- botor::s3_read(
+  uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv",
+  fun = readr::read_csv)
 ```
 
 
@@ -674,21 +703,27 @@ We merge the datasets with offenders using the combination of fields that togeth
 
 
 ```r
-offenders_trial <- offenders_trial %>% dplyr::rename(BIRTH_DATE=DoB) 
+offenders_trial <- offenders_trial %>% dplyr::rename(BIRTH_DATE = DoB) 
 ```
 
 Now the variables that together form a unique identifier have the same names, we can do the merge:
 
 
 ```r
-offenders_merge <- dplyr::inner_join(offenders, offenders_trial, by=c("LAST", "BIRTH_DATE")) 
+offenders_merge <- dplyr::inner_join(
+  x = offenders,
+  y = offenders_trial,
+  by = c("LAST", "BIRTH_DATE")) 
 ```
 
 Alternatively, instead of renaming the columns we want to join two datasets on that have different names, we can simply provide both column names to the `by` argument of `inner_join()`, as below:
 
 
 ```r
-offenders_merge <- dplyr::inner_join(offenders, offenders_trial, by=c("LAST", "BIRTH_DATE" = "DoB")) 
+offenders_merge <- dplyr::inner_join(
+  x = offenders, 
+  y = offenders_trial,
+  by = c("LAST", "BIRTH_DATE" = "DoB")) 
 ```
 
 For more information about the different sorts of joins and other data transformation functions see the 'Data Transformation Cheat Sheet' at: https://www.rstudio.com/resources/cheatsheets/  
@@ -729,7 +764,7 @@ We can look at the `HEIGHT` variable as previously:
 ```r
 height_table <- offenders %>% 
   dplyr::group_by(HEIGHT) %>% 
-  dplyr::summarise(Count=n())
+  dplyr::summarise(Count= dplyr::n())
 ```
 
 Then we can view the `height_table` we've made which will include the number of missing values the height variable contains:

--- a/Intro_markdown.md
+++ b/Intro_markdown.md
@@ -237,7 +237,7 @@ Although including the library call makes the code longer, it also makes it more
 
 However there are exceptions to this. In particular, we want to use the operator `%>%` (pipe) without specifying the package name, because it would be bad for our readability. So we do want to load the package `magrittr`.
 
-Please load `magrittr` by one of the methods described above (which do you you think would be best practice overall)?
+If you haven't already, load `magrittr` by one of the methods described above (which do you you think would be best practice overall)?
 
 To know more about a package, it is always useful to read the associated documentation:
 
@@ -539,7 +539,7 @@ But if we want to count all the rows in the `regional_gender_average` dataset wi
 ```r
 regional_gender_average %>% 
  dplyr::ungroup() %>% 
- dplyr::summarise(Count = dlyr::n())
+ dplyr::summarise(Count = dplyr::n())
 ```
 The `summarise(Count = n())` above can also be replaced with `tally()` to count the number of rows in a dataset.
 

--- a/Intro_markdown.md
+++ b/Intro_markdown.md
@@ -151,7 +151,7 @@ You can check what the working directory currently is by using the `getwd()` com
 getwd()
 ```
 
-If you want to change the working directory to a specific repository/folder, you can use the `setwd()` command as follows:
+If you want to change the working directory to a specific repository/folder - in this case `IntroRTraining`, you can use the `setwd()` command as follows:
 
 
 ```r
@@ -191,7 +191,7 @@ To synchronise your working R environment with this course's repo, run
 ```r
 renv::restore()
 ```
-If you have no installed `renv` yet, you can do this with
+If you have not installed `renv` yet, you can do this with
 
 
 ```r
@@ -231,9 +231,9 @@ lubridate::days_in_month(Sys.Date())
 
 Here we're using function `days_in_month()` from the `lubridate` package. We're passing to it the current date.
 
-Functions that are 'base' R, or part of a core package such as the `stats` package, which we use below, do not require.
+Functions that are 'base' R, or part of a core package such as the `stats` package, which we use below, do not require the package/library name to precede the function name when the function is called.
 
-Although including the library call makes the code longer, it also makes it more readable, as anyone who is unfamiliar with the code can see very easily where functions are being called, and which packages are being used. It also avoids the wrong function being called if two functions have the same name and are from different packages. If the package isn't specified by using the double-colon notation then R will use the function from your most recently loaded package and will warn you when you load a package if there is some overlap.
+Although including the library call makes the code longer, it also makes it more readable, as anyone who is unfamiliar with the code can see very easily where functions are being called, and which packages are being used. It also avoids the wrong function being called if two functions have the same name and are from different packages. If the package isn't specified by using the double-colon notation then R will use the function from your most recently loaded package. You will be warned about any overlaps when you load a package.
 
 However there are exceptions to this. In particular, we want to use the operator `%>%` (pipe) without specifying the package name, because it would be bad for our readability. So we do want to load the package `magrittr`.
 
@@ -273,10 +273,28 @@ Note that this code is only suitable for csv files, so it is assumed by default 
 
 There are other commands and various packages that can be used to import datasets with other extensions (e.g. .xls) e.g. see http://www.statmethods.net/input/importingdata.html.
 
-
 ### Importing data from the Analytical Platform cloud storage (Amazon S3)
 
-Data that has been approved for storage on the Analytical Platform is generally stored in a data source (referred to as a 'bucket') on Amazon S3, which is the cloud storage solution used by the Analytical Platform. To import data from S3 we use `botor`.
+Data that has been approved for storage on the Analytical Platform is generally stored in a data source (referred to as a 'bucket') on Amazon S3, which is the cloud storage solution used by the Analytical Platform. There are two options for packages that can be used to import data from S3: `Rs3tools` and `botor`.
+
+#### Importing data using the `Rs3tools` package {-}
+
+The `Rs3tools` package is maintained by other analysts in MoJ and has the advantage of being R-native, resulting in it being quicker to install than `botor` (which requires a Python environment). Here's how it can be installed:
+
+
+```r
+install.packages("moj-analytical-services/Rs3tools")
+```
+
+And here's how to use `Rs3tools` to read in the `offenders` dataset that we'll be using in this session from the 'alpha-r-training' S3 bucket:
+
+
+```r
+offenders <- Rs3tools::s3_path_to_full_df(
+  s3_path = "alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv")
+```
+
+#### Importing data using the `botor` package {-}
 
 The `botor` package provides an alternative to `Rs3tools`. It's maintained by the wider R community and contains a larger range of functionality. Reading from S3 using `botor` can be done using this command:
 
@@ -286,9 +304,7 @@ offenders <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv",
   fun = readr::read_csv)
 ```
-
-More information on `botor` can be found on the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
-
+More information on `Rs3tools` and `botor` can be found in the [AP guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/data/amazon-s3/#rstudio).
 
 ## Inspecting the dataset
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ In advance of the training session please follow these setup steps:
  - If you do not already have an account on the Analytical Platform. following these instructions to sign up for one: https://user-guidance.services.alpha.mojanalytics.xyz/get-started.html
  - If you're using RStudio on the Analytical Platform for the first time, you will first need to deploy it: https://user-guidance.services.alpha.mojanalytics.xyz/tools/control-panel.html
  - Open RStudio from your Analytical Platform control panel: https://user-guidance.services.alpha.mojanalytics.xyz/tools/control-panel.html
- - If you've not used Git/GitHub with you RStudio account before, follow these steps to connect your RStudio to your GitHub account: https://user-guidance.services.alpha.mojanalytics.xyz/github.html#setup-github-keys-to-access-it-from-r-studio-and-jupyter
- - Clone this GitHub repository by following step 1 here: https://user-guidance.services.alpha.mojanalytics.xyz/github.html#r-studio
+ - If you've not used Git/GitHub with you RStudio account before, follow these steps to connect your RStudio to your GitHub account: https://user-guidance.analytical-platform.service.justice.gov.uk/github/rstudio-git.html#work-with-git-in-rstudio
+ - Clone this GitHub repository by following the same process as here, but using the course's repo:
+ https://user-guidance.analytical-platform.service.justice.gov.uk/tools/create-a-derived-table/instructions/#clone-the-repository-using-the-rstudio-gui
  - In the Console window in RStudio, enter this command to make sure you have the required packages installed: `renv::restore()`
  - Request access to the alpha-r-training bucket on Amazon S3 (which is used to store some example data) from the session organisers or by posting on the #intro_r channel on ASD Slack. To check if you can access the bucket you can run the following code in the RStudio Console, which should output a list of files stored in the bucket: `botor::s3_ls('s3://alpha-r-training')`
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ In advance of the training session please follow these setup steps:
  - If you're using RStudio on the Analytical Platform for the first time, you will first need to deploy it: https://user-guidance.services.alpha.mojanalytics.xyz/tools/control-panel.html
  - Open RStudio from your Analytical Platform control panel: https://user-guidance.services.alpha.mojanalytics.xyz/tools/control-panel.html
  - If you've not used Git/GitHub with you RStudio account before, follow these steps to connect your RStudio to your GitHub account: https://user-guidance.analytical-platform.service.justice.gov.uk/github/rstudio-git.html#work-with-git-in-rstudio
- - Clone this GitHub repository by following the same process as here, but using the course's repo:
- https://user-guidance.analytical-platform.service.justice.gov.uk/tools/create-a-derived-table/instructions/#clone-the-repository-using-the-rstudio-gui
+ - Clone this GitHub repository by following the same process as here:
+ https://user-guidance.analytical-platform.service.justice.gov.uk/github/rstudio-git.html#step-1-navigate-to-your-platform-r-studio-and-make-a-copy-of-the-github-project-in-your-r-studio
  - In the Console window in RStudio, enter this command to make sure you have the required packages installed: `renv::restore()`
  - Request access to the alpha-r-training bucket on Amazon S3 (which is used to store some example data) from the session organisers or by posting on the #intro_r channel on ASD Slack. To check if you can access the bucket you can run the following code in the RStudio Console, which should output a list of files stored in the bucket: `botor::s3_ls('s3://alpha-r-training')`
 

--- a/code_instructor.R
+++ b/code_instructor.R
@@ -46,7 +46,7 @@ offenders %>%
 # Q3 Produce a table showing the counts of height (including missing values).
 counts_of_height <- offenders %>% 
   dplyr::group_by(HEIGHT) %>%
-  dplyr::summarise(Count = n())
+  dplyr::summarise(Count = dplyr::n())
 
 # Or
 counts_of_height <- offenders %>% 
@@ -68,11 +68,17 @@ View(offenders_new)
 # 4.2 Exercises -----------------------------------------------------------
 # Q1 Read in dataset ‘FTSE_12_14.csv’ and convert the variable date to class date. 
 
-# analytical platform amazon server:
-ftse <- botor::s3_read("s3://alpha-r-training/intro-r-training/FTSE_12_14.csv", read_csv)
+# Read in ftse data using Rs3tools
+ftse <- Rs3tools::s3_path_to_full_df(
+  s3_path = "s3://alpha-r-training/intro-r-training/FTSE_12_14.csv")
 
-#If dataset is in working directory:
-# ftse <- read_csv("FTSE_12_14.csv")
+# Read in ftse data using botor
+ftse <- botor::s3_read(
+  uri = "s3://alpha-r-training/intro-r-training/FTSE_12_14.csv",
+  fun = readr::read_csv)
+
+# Read in data from the working directory:
+ftse <- readr::read_csv(file = "FTSE_12_14.csv")
 
 # first have a look at what format the date is in
 str(ftse)

--- a/code_participant.R
+++ b/code_participant.R
@@ -211,7 +211,7 @@ ftse <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/FTSE_12_14.csv",
   fun = readr::read_csv)
 
-# To read the file in directly from the wd, use:
+# To read the file in directly from the working directory use:
 # ftse <- readr::read_csv(file = "FTSE_12_14.csv")
 
 

--- a/code_participant.R
+++ b/code_participant.R
@@ -54,6 +54,9 @@ help(package = dplyr)
 # Method 1: Rs3tools
 # Here the function s3_path_to_full_df() from the package Rs3tools is directly
 # reading in the the file from the uri
+
+renv::install("moj-analytical-services/Rs3tools")
+
 offenders <- Rs3tools::s3_path_to_full_df(
   s3_path = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv"
 )

--- a/code_participant.R
+++ b/code_participant.R
@@ -49,14 +49,24 @@ help(package = dplyr)
 
 # 2.3 Importing data
 
-# From the updated Analytical Platform server
+# Use one of the methods below to read in the data
+
+# Method 1: Rs3tools
+# Here the function s3_path_to_full_df() from the package Rs3tools is directly
+# reading in the the file from the uri
+offenders <- Rs3tools::s3_path_to_full_df(
+  s3_path = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv"
+)
+
+# Method 2: botor
 # Here the function s3_read is using the function read_csv to read the data it
-# downloads
+# downloads from the uri
 offenders <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv",
   fun = readr::read_csv)
 
-# If the csv file is in your working directory
+# Method 3: local file read
+# If the csv file is in your working directory:
 offenders <- readr::read_csv(file = "Offenders_Chicago_Police_Dept_Main.csv")
 
 # 2.4 Inspecting the dataset
@@ -206,25 +216,34 @@ offenders <- offenders %>%
 
 # 4.2 Exercises
 
-#Read in ftse data using botor
+# Read in ftse data using Rs3tools
+ftse <- Rs3tools::s3_path_to_full_df(
+  s3_path = "s3://alpha-r-training/intro-r-training/FTSE_12_14.csv")
+
+# Read in ftse data using botor
 ftse <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/FTSE_12_14.csv",
   fun = readr::read_csv)
 
-# To read the file in directly from the working directory use:
-# ftse <- readr::read_csv(file = "FTSE_12_14.csv")
+# Read in data from the working directory:
+ftse <- readr::read_csv(file = "FTSE_12_14.csv")
 
 
 # 5 Merging and exporting data --------------------------------------------
 # 5.1 Merging datasets
 
-# Read in data from s3 on Analytical Platform:
+# Data read using Rs3tools:
+offenders_trial <- Rs3tools::s3_path_to_full_df(
+  s3_path = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv")
+
+# Data read using botor:
 offenders_trial <- botor::s3_read(
   uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv",
   fun = readr::read_csv)
 
-# Read in data on DOM1 (assuming file in your working directory):
-# offenders_trial <- readr::read_csv("Offenders_Chicago_Police_Dept_Trial.csv")
+# Read in data from the working directory:
+offenders_trial <- readr::read_csv("Offenders_Chicago_Police_Dept_Trial.csv")
+
 
 offenders_trial <- offenders_trial %>% dplyr::rename( BIRTH_DATE = DoB) 
 

--- a/code_participant.R
+++ b/code_participant.R
@@ -110,27 +110,30 @@ offenders_anonymous <- offenders %>%
 
 regional_gender_average <- offenders %>% 
   dplyr::group_by(REGION, GENDER) %>%
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS)) 
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   .groups = 'keep') 
 
 regional_gender_average <- offenders %>% 
   dplyr::group_by(REGION, GENDER) %>%
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS), Count=n()) 
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS),
+                   Count = dplyr::n(),
+                   .groups = 'keep') 
 
 offenders %>% 
   dplyr::count(REGION, GENDER)
 
 regional_gender_average %>% 
-  dplyr::summarise(Count=n())
+  dplyr::summarise(Count = dplyr::n())
 
 regional_gender_average %>% 
   dplyr::ungroup() %>% 
-  dplyr::summarise(Count=n())
+  dplyr::summarise(Count = dplyr::n())
 
 # 3.3 Filter
 
 offenders %>% 
   dplyr::group_by(SENTENCE) %>% 
-  dplyr::summarise(Count = n())
+  dplyr::summarise(Count = dplyr::n())
 
 offenders %>% 
   dplyr::count(SENTENCE)
@@ -138,7 +141,7 @@ offenders %>%
 crt_order_average <- offenders %>% 
   dplyr::filter(SENTENCE == "Court_order" & AGE > 50) %>% 
   dplyr::group_by(REGION, GENDER) %>% 
-  dplyr::summarise(Ave = mean(PREV_CONVICTIONS))
+  dplyr::summarise(Ave = mean(PREV_CONVICTIONS), .groups = 'keep')
 
 # 3.4 Rename
 
@@ -162,12 +165,16 @@ offenders_anonymous <- offenders %>%
 # 3.6 If_else
 
 offenders <- offenders %>% 
-  dplyr::mutate(weight_under_170 = if_else(WEIGHT<170,1,0))
+  dplyr::mutate(weight_under_170 =
+                  dplyr::if_else(condition = WEIGHT < 170,
+                                 true = 1,
+                                 false = 0))
+
+offenders <- offenders %>% dplyr::mutate(
+  weight_under_170 = dplyr::if_else(WEIGHT<170, 1, 0))
 
 # Dates -------------------------------------------------------------------
 # 4.1 Manipulating dates
-
-library(lubridate)
 
 lubridate::today()
 
@@ -189,7 +196,10 @@ offenders <- offenders %>%
   dplyr::mutate(month = lubridate::month(DoB_formatted))
 
 offenders <- offenders %>%
-  dplyr::mutate(weekday = lubridate::wday(DoB_formatted, label=TRUE, abbr=FALSE))
+  dplyr::mutate(weekday = lubridate::wday(
+    x = DoB_formatted,
+    label = TRUE,
+    abbr = FALSE))
 
 offenders <- offenders %>%
   dplyr::mutate(days_before_2000 = lubridate::ymd("2000-01-01") - DoB_formatted)
@@ -197,26 +207,36 @@ offenders <- offenders %>%
 # 4.2 Exercises
 
 #Read in ftse data using botor
-ftse <- botor::s3_read("s3://alpha-r-training/intro-r-training/FTSE_12_14.csv", read_csv)
+ftse <- botor::s3_read(
+  uri = "s3://alpha-r-training/intro-r-training/FTSE_12_14.csv",
+  fun = readr::read_csv)
 
-# To read the file in directly from the wd (for those on borrowed macs you will need to do this) use
-ftse <- readr::read_csv("FTSE_12_14.csv")
+# To read the file in directly from the wd, use:
+# ftse <- readr::read_csv(file = "FTSE_12_14.csv")
 
 
 # 5 Merging and exporting data --------------------------------------------
 # 5.1 Merging datasets
 
 # Read in data from s3 on Analytical Platform:
-offenders_trial <- botor::s3_read("s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv", read_csv)
+offenders_trial <- botor::s3_read(
+  uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Trial.csv",
+  fun = readr::read_csv)
 
 # Read in data on DOM1 (assuming file in your working directory):
-offenders_trial <- readr::read_csv("Offenders_Chicago_Police_Dept_Trial.csv")
+# offenders_trial <- readr::read_csv("Offenders_Chicago_Police_Dept_Trial.csv")
 
-offenders_trial <- offenders_trial %>% dplyr::rename(BIRTH_DATE=DoB) 
+offenders_trial <- offenders_trial %>% dplyr::rename( BIRTH_DATE = DoB) 
 
-offenders_merge <- dplyr::inner_join(offenders, offenders_trial, by=c("LAST", "BIRTH_DATE")) 
+offenders_merge <- dplyr::inner_join(
+  x = offenders, 
+  y = offenders_trial,
+  by = c("LAST", "BIRTH_DATE")) 
 
-offenders_merge <- dplyr::inner_join(offenders, offenders_trial, by=c("LAST", "BIRTH_DATE" = "DoB")) 
+offenders_merge <- dplyr::inner_join(
+  x = offenders,
+  y = offenders_trial,
+  by = c("LAST", "BIRTH_DATE" = "DoB")) 
 
 men <- offenders %>% dplyr::filter(GENDER == "MALE") 
 women <- offenders %>% dplyr::filter(GENDER == "FEMALE")
@@ -230,7 +250,7 @@ nrow(offenders) # 1413 rows
 
 height_table <- offenders %>% 
   dplyr::group_by(HEIGHT) %>% 
-  dplyr::summarise(Count=n())
+  dplyr::summarise(Count = dplyr::n())
 
 View(height_table)
 

--- a/code_participant.R
+++ b/code_participant.R
@@ -25,26 +25,39 @@ setwd("~/IntroRTraining")
 
 # 2.2 Packages
 
-# renv restore (only needs running if you're cloning the repo for the first time)
-# If you do not have the renv package, please install it by running install.packages("renv") in the console.
+# renv restore (only needs running if you're cloning the repo for the first
+# time)
+# If you do not have the renv package, please install it by running
+# install.packages("renv") in the console.
 renv::restore()
 
-# Install packages (unnecessary if on Analytical Platform)
-install.packages("tidyverse")
+# This the command to install/update a package using renv.
+# If you are not using renv, e.g. if you are not on the AP, then the command is
+# install.packages('tidyverse')
+renv::install("tidyverse")
 
-# Load packages
-library("tidyverse")
+# RESTART, with the red button on the top right.
 
-help(package=dplyr)
+# This is the command to load a package. It is generally considered better
+# not to load packages, but to call the package at the time the function is
+# called. However, 'magrittr' is an exception (more on this below).
+
+library('magrittr')
+# If you get an error, it might be because of not restarting above.
+
+help(package = dplyr)
 
 # 2.3 Importing data
 
-# If the csv file is in your working directory
-offenders <- readr::read_csv("Offenders_Chicago_Police_Dept_Main.csv")
-
 # From the updated Analytical Platform server
-offenders <- botor::s3_read("s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv", read_csv)
+# Here the function s3_read is using the function read_csv to read the data it
+# downloads
+offenders <- botor::s3_read(
+  uri = "s3://alpha-r-training/intro-r-training/Offenders_Chicago_Police_Dept_Main.csv",
+  fun = readr::read_csv)
 
+# If the csv file is in your working directory
+offenders <- readr::read_csv(file = "Offenders_Chicago_Police_Dept_Main.csv")
 
 # 2.4 Inspecting the dataset
 
@@ -78,13 +91,14 @@ offenders$GENDER <- relevel(offenders$GENDER, "MALE")
 
 offenders$GENDER <- as.character(offenders$GENDER) 
 
-# 3.	Data wrangling and ‘group by’ calculations --------------------------------------
+# 3.	Data wrangling and ‘group by’ calculations -------------------------------
 
 # 3.1 Select
 
 ?dplyr::select
 
-offenders_anonymous <- dplyr::select(offenders, BIRTH_DATE, WEIGHT, PREV_CONVICTIONS)
+offenders_anonymous <- dplyr::select(offenders, BIRTH_DATE, WEIGHT,
+                                     PREV_CONVICTIONS)
 
 offenders_anonymous <- offenders %>% 
   dplyr::select(BIRTH_DATE, WEIGHT, PREV_CONVICTIONS)

--- a/renv.lock
+++ b/renv.lock
@@ -14,20 +14,6 @@
     "Name": null
   },
   "Packages": {
-    "DBI": {
-      "Package": "DBI",
-      "Version": "1.1.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "dcd1743af4336156873e3ce3c950b8b9"
-    },
-    "MASS": {
-      "Package": "MASS",
-      "Version": "7.3-54",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "0e59129db205112e3963904db67fd0dc"
-    },
     "Matrix": {
       "Package": "Matrix",
       "Version": "1.3-4",
@@ -39,15 +25,8 @@
       "Package": "R6",
       "Version": "2.5.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "470851b6d5d0ac559e9d01bb352b4021"
-    },
-    "RColorBrewer": {
-      "Package": "RColorBrewer",
-      "Version": "1.1-2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "e031418365a7f7a766181ab5a41a5716"
     },
     "Rcpp": {
       "Package": "Rcpp",
@@ -60,7 +39,7 @@
       "Package": "RcppTOML",
       "Version": "0.1.7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "f8a578aa91321ecec1292f1e2ffadeda"
     },
     "Rs3tools": {
@@ -79,112 +58,70 @@
       "Package": "askpass",
       "Version": "1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "e8a22846fff485f0be3770c2da758713"
-    },
-    "assertthat": {
-      "Package": "assertthat",
-      "Version": "0.2.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "50c838a310445e954bc13f26f26a6ecf"
     },
     "backports": {
       "Package": "backports",
       "Version": "1.4.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "c39fbec8a30d23e721980b8afb31984c"
     },
     "base64enc": {
       "Package": "base64enc",
       "Version": "0.1-3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
     "bit": {
       "Package": "bit",
       "Version": "4.0.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "f36715f14d94678eea9933af927bc15d"
     },
     "bit64": {
       "Package": "bit64",
       "Version": "4.0.5",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "9fe98599ca456d6552421db0d6772d8f"
-    },
-    "blob": {
-      "Package": "blob",
-      "Version": "1.2.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "dc5f7a6598bb025d20d66bb758f12879"
     },
     "botor": {
       "Package": "botor",
       "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "dc6ab51cf3922fdc38421f4dc79fd2af"
-    },
-    "broom": {
-      "Package": "broom",
-      "Version": "0.7.12",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "bfa8a039d77ae8d5413254e572c8abea"
-    },
-    "callr": {
-      "Package": "callr",
-      "Version": "3.7.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "461aa75a11ce2400245190ef5d3995df"
-    },
-    "cellranger": {
-      "Package": "cellranger",
-      "Version": "1.1.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f61dbaec772ccd2e17705c1e872e9e7c"
     },
     "checkmate": {
       "Package": "checkmate",
       "Version": "2.0.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "a667800d5f0350371bedeb8b8b950289"
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.2.0",
+      "Version": "3.6.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "1bdb126893e9ce6aae50ad1d6fc32faf"
+      "Hash": "89e6d8219950eac806ae0c489052048a"
     },
     "clipr": {
       "Package": "clipr",
       "Version": "0.8.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "3f038e5ac7f41d4ac41ce658c85e3042"
-    },
-    "colorspace": {
-      "Package": "colorspace",
-      "Version": "2.0-3",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "bb4341986bc8b914f0f0acf2e4a3f2f7"
     },
     "cpp11": {
       "Package": "cpp11",
       "Version": "0.4.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "fa53ce256cd280f468c080a58ea5ba8c"
     },
     "crayon": {
@@ -201,20 +138,6 @@
       "Repository": "RSPM",
       "Hash": "022c42d49c28e95d69ca60446dbabf88"
     },
-    "data.table": {
-      "Package": "data.table",
-      "Version": "1.14.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "36b67b5adf57b292923f5659f5f0c853"
-    },
-    "dbplyr": {
-      "Package": "dbplyr",
-      "Version": "2.1.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "1f37fa4ab2f5f7eded42f78b9a887182"
-    },
     "digest": {
       "Package": "digest",
       "Version": "0.6.29",
@@ -224,24 +147,10 @@
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.0.8",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "ef47665e64228a17609d6df877bf86f2"
-    },
-    "dtplyr": {
-      "Package": "dtplyr",
-      "Version": "1.2.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f5d195cd5fcc0a77499d9da698ef2ea3"
-    },
-    "ellipsis": {
-      "Package": "ellipsis",
-      "Version": "0.3.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
+      "Hash": "dea6970ff715ca541c387de363ff405e"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -257,40 +166,12 @@
       "Repository": "RSPM",
       "Hash": "f28149c2d7a1342a834b314e95e67260"
     },
-    "farver": {
-      "Package": "farver",
-      "Version": "2.1.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "c98eb5133d9cb9e1622b8691487f11bb"
-    },
     "fastmap": {
       "Package": "fastmap",
-      "Version": "1.1.0",
+      "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
-    },
-    "forcats": {
-      "Package": "forcats",
-      "Version": "0.5.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "81c3244cab67468aac4c60550832655d"
-    },
-    "fs": {
-      "Package": "fs",
-      "Version": "1.5.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "7c89603d81793f0d5486d91ab1fc6f1d"
-    },
-    "gargle": {
-      "Package": "gargle",
-      "Version": "1.2.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "9d234e6a87a6f8181792de6dc4a00e39"
+      "Hash": "f7736a18de97dea803bde0a2daaafb27"
     },
     "gdata": {
       "Package": "gdata",
@@ -306,40 +187,12 @@
       "Repository": "RSPM",
       "Hash": "177475892cf4a55865868527654a7741"
     },
-    "ggplot2": {
-      "Package": "ggplot2",
-      "Version": "3.3.5",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "d7566c471c7b17e095dd023b9ef155ad"
-    },
     "glue": {
       "Package": "glue",
       "Version": "1.6.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "4f2596dfb05dac67b9dc558e5c6fba2e"
-    },
-    "googledrive": {
-      "Package": "googledrive",
-      "Version": "2.0.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "c3a25adbbfbb03f12e6f88c5fb1f3024"
-    },
-    "googlesheets4": {
-      "Package": "googlesheets4",
-      "Version": "1.0.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "9a6564184dc4a81daea4f1d7ce357c6a"
-    },
-    "gtable": {
-      "Package": "gtable",
-      "Version": "0.3.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "ac5c6baf7822ce8732b343f14c072c4d"
     },
     "gtools": {
       "Package": "gtools",
@@ -348,33 +201,26 @@
       "Repository": "RSPM",
       "Hash": "88bb96eaf7140cdf29e374ef74182220"
     },
-    "haven": {
-      "Package": "haven",
-      "Version": "2.4.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "10bec8a8264f3eb59531e8c4c0303f96"
-    },
     "here": {
       "Package": "here",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "24b224366f9c2e7534d2344d10d59211"
     },
     "highr": {
       "Package": "highr",
       "Version": "0.9",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "8eb36c8125038e648e5d111c0d7b2ed4"
     },
     "hms": {
       "Package": "hms",
-      "Version": "1.1.1",
+      "Version": "1.1.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "5b8a2dd0fdbe2ab4f6081e6c7be6dfca"
+      "Hash": "b59377caa7ed00fa41808342002138f9"
     },
     "htmltools": {
       "Package": "htmltools",
@@ -385,38 +231,24 @@
     },
     "httr": {
       "Package": "httr",
-      "Version": "1.4.2",
+      "Version": "1.4.6",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "a525aba14184fec243f9eaec62fbed43"
-    },
-    "ids": {
-      "Package": "ids",
-      "Version": "1.0.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "99df65cfef20e525ed38c3d2577f7190"
-    },
-    "isoband": {
-      "Package": "isoband",
-      "Version": "0.2.5",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "7ab57a6de7f48a8dc84910d1eca42883"
+      "Hash": "7e5e3cbd2a7bc07880c94e22348fb661"
     },
     "jquerylib": {
       "Package": "jquerylib",
       "Version": "0.1.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "5aab57a3bd297eee1c1d862735972182"
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.8.0",
+      "Version": "1.8.5",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "d07e729b27b372429d42d24d503613a0"
+      "Hash": "3ee4d9899e4db3e976fc82b98d24a31a"
     },
     "knitr": {
       "Package": "knitr",
@@ -424,13 +256,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "a4ec675eb332a33fe7b7fe26f70e1f98"
-    },
-    "labeling": {
-      "Package": "labeling",
-      "Version": "0.4.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "3d5108641f47470611a32d0bdf357a72"
     },
     "lattice": {
       "Package": "lattice",
@@ -441,66 +266,38 @@
     },
     "lifecycle": {
       "Package": "lifecycle",
-      "Version": "1.0.1",
+      "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "a6b6d352e3ed897373ab19d8395c98d0"
+      "Hash": "001cecbeac1cff9301bdc3775ee46a86"
     },
     "logger": {
       "Package": "logger",
       "Version": "0.2.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "c269b06beb2bbadb0d058c0e6fa4ec3d"
     },
     "lubridate": {
       "Package": "lubridate",
-      "Version": "1.8.0",
+      "Version": "1.9.2",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "2ff5eedb6ee38fb1b81205c73be1be5a"
+      "Hash": "e25f18436e3efd42c7c590a1c4c15390"
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "2.0.2",
+      "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "cdc87ecd81934679d1557633d8e1fe51"
-    },
-    "mgcv": {
-      "Package": "mgcv",
-      "Version": "1.8-38",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "be3c61ffbb1e3d3b3df214d192ac5444"
+      "Hash": "7ce2733a9826b3aeb1775d56fd305472"
     },
     "mime": {
       "Package": "mime",
       "Version": "0.12",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
-    },
-    "modelr": {
-      "Package": "modelr",
-      "Version": "0.1.8",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "9fd59716311ee82cba83dc2826fc5577"
-    },
-    "munsell": {
-      "Package": "munsell",
-      "Version": "0.5.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "6dfe8bf774944bd5595785e3229d8771"
-    },
-    "nlme": {
-      "Package": "nlme",
-      "Version": "3.1-153",
-      "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2d632e0d963a653a0329756ce701ecdd"
+      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
     },
     "openssl": {
       "Package": "openssl",
@@ -513,197 +310,162 @@
       "Package": "paws",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "bf7208e16e227eebfaa1ba235a662b2f"
     },
     "paws.analytics": {
       "Package": "paws.analytics",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "cde4b7e77dba080d60160959c7076fe3"
     },
     "paws.application.integration": {
       "Package": "paws.application.integration",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "a8091ac6c39991cec0249a9dde11b9ad"
     },
     "paws.common": {
       "Package": "paws.common",
       "Version": "0.5.6",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "3cf4d48f231f58a989c9eb7eb8ffd5de"
     },
     "paws.compute": {
       "Package": "paws.compute",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "63a00ce475b39971359a8d74ce5dd07a"
     },
     "paws.cost.management": {
       "Package": "paws.cost.management",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "9873567a16984201cdd0237a47acd45a"
     },
     "paws.customer.engagement": {
       "Package": "paws.customer.engagement",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "dca4461bf514a09d22044b0c4f75f321"
     },
     "paws.database": {
       "Package": "paws.database",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "46fdfc1be98b7db1170bbaca378f7fe0"
     },
     "paws.developer.tools": {
       "Package": "paws.developer.tools",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "7655293a28c26420c92b20e7297930f2"
     },
     "paws.end.user.computing": {
       "Package": "paws.end.user.computing",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "6f9f5ae02a8eeeae18f200e135532d87"
     },
     "paws.machine.learning": {
       "Package": "paws.machine.learning",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "4b8af7e104339d7948c8a19eab149a17"
     },
     "paws.management": {
       "Package": "paws.management",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "2bd279ee9623d3aef70983e7ffc27d05"
     },
     "paws.networking": {
       "Package": "paws.networking",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "c626ccbe4dc606373d18a0e28b9f3d8c"
     },
     "paws.security.identity": {
       "Package": "paws.security.identity",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "8d547554ab0d24fc53c47fe4c9eb9f91"
     },
     "paws.storage": {
       "Package": "paws.storage",
       "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "caac905cd1521f86f4e6997b0e29f731"
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.7.0",
+      "Version": "1.9.0",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "51dfc97e1b7069e9f7e6f83f3589c22e"
+      "Hash": "15da5a8412f317beeee6175fbc76f4bb"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
       "Version": "2.0.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
     "png": {
       "Package": "png",
       "Version": "0.1-7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "03b7076c234cb3331288919983326c55"
     },
     "prettyunits": {
       "Package": "prettyunits",
       "Version": "1.1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "95ef9167b75dde9d2ccc3c7528393e7e"
-    },
-    "processx": {
-      "Package": "processx",
-      "Version": "3.5.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "0cbca2bc4d16525d009c4dbba156b37c"
     },
     "progress": {
       "Package": "progress",
       "Version": "1.2.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "14dc9f7a3c91ebb14ec5bb9208a07061"
-    },
-    "ps": {
-      "Package": "ps",
-      "Version": "1.6.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "32620e2001c1dce1af49c49dccbb9420"
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "0.3.4",
+      "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "97def703420c8ab10d8f0e6c72101e02"
+      "Hash": "d71c815267c640f17ddbf7f16144b4bb"
     },
     "rappdirs": {
       "Package": "rappdirs",
       "Version": "0.3.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
     },
     "readr": {
       "Package": "readr",
-      "Version": "2.1.2",
+      "Version": "2.1.4",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "9c59de1357dc209868b5feb5c9f0fe2f"
-    },
-    "readxl": {
-      "Package": "readxl",
-      "Version": "1.3.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "63537c483c2dbec8d9e3183b3735254a"
-    },
-    "rematch": {
-      "Package": "rematch",
-      "Version": "1.0.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "c66b930d20bb6d858cd18e1cebcfae5c"
-    },
-    "rematch2": {
-      "Package": "rematch2",
-      "Version": "2.1.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "76c9e04c712a05848ae7a23d2f170a40"
+      "Hash": "b5047343b3825f37ad9d3b5d89aa1078"
     },
     "renv": {
       "Package": "renv",
@@ -711,13 +473,6 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "079cb1f03ff972b30401ed05623cbe92"
-    },
-    "reprex": {
-      "Package": "reprex",
-      "Version": "2.0.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "911d101becedc0fde495bd910984bdc8"
     },
     "reticulate": {
       "Package": "reticulate",
@@ -728,10 +483,10 @@
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.0.1",
+      "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "3bf0219f19d9f5b3c682acbb3546a151"
+      "Hash": "a85c767b55f0bf9b7ad16c6d7baee5bb"
     },
     "rmarkdown": {
       "Package": "rmarkdown",
@@ -744,36 +499,8 @@
       "Package": "rprojroot",
       "Version": "2.0.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "249d8cd1e74a8f6a26194a91b47f21d1"
-    },
-    "rstudioapi": {
-      "Package": "rstudioapi",
-      "Version": "0.13",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
-    },
-    "rvest": {
-      "Package": "rvest",
-      "Version": "1.0.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "bb099886deffecd6f9b298b7d4492943"
-    },
-    "scales": {
-      "Package": "scales",
-      "Version": "1.1.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "6f76f71042411426ec8df6c54f34e6dd"
-    },
-    "selectr": {
-      "Package": "selectr",
-      "Version": "0.4-2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "3838071b66e0c566d55cc26bd6e27bf4"
     },
     "stringi": {
       "Package": "stringi",
@@ -784,45 +511,38 @@
     },
     "stringr": {
       "Package": "stringr",
-      "Version": "1.4.0",
+      "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "0759e6b6c0957edb1311028a49a35e76"
+      "Hash": "671a4d384ae9d32fc47a14e98bfa3dc8"
     },
     "sys": {
       "Package": "sys",
       "Version": "3.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "b227d13e29222b4574486cfcbde077fa"
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.6",
+      "Version": "3.2.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "8a8f02d1934dfd6431c671361510dd0b"
-    },
-    "tidyr": {
-      "Package": "tidyr",
-      "Version": "1.2.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "d8b95b7fee945d7da6888cf7eb71a49c"
+      "Hash": "a84e2cc86d07289b3b6f5069df7a004c"
     },
     "tidyselect": {
       "Package": "tidyselect",
-      "Version": "1.1.2",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "17f6da8cfd7002760a859915ce7eef8f"
+      "Hash": "79540e5fcd9e0435af547d885f184fd5"
     },
-    "tidyverse": {
-      "Package": "tidyverse",
-      "Version": "1.3.1",
+    "timechange": {
+      "Package": "timechange",
+      "Version": "0.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "fc4c72b6ae9bb283416bd59a3303bbab"
+      "Repository": "CRAN",
+      "Hash": "8548b44f79a35ba1791308b61e6012d7"
     },
     "tinytex": {
       "Package": "tinytex",
@@ -845,33 +565,19 @@
       "Repository": "RSPM",
       "Hash": "c9c462b759a5cc844ae25b5942654d13"
     },
-    "uuid": {
-      "Package": "uuid",
-      "Version": "1.0-3",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "2097822ba5e4440b81a0c7525d0315ce"
-    },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.3.8",
+      "Version": "0.6.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "ecf749a1b39ea72bd9b51b76292261f1"
-    },
-    "viridisLite": {
-      "Package": "viridisLite",
-      "Version": "0.4.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "55e157e2aa88161bdb0754218470d204"
+      "Hash": "d0ef2856b83dc33ea6e255caf6229ee2"
     },
     "vroom": {
       "Package": "vroom",
-      "Version": "1.5.7",
+      "Version": "1.6.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "976507b5a105bc3bdf6a5a5f29e0684f"
+      "Hash": "8318e64ffb3a70e652494017ec455561"
     },
     "withr": {
       "Package": "withr",
@@ -891,7 +597,7 @@
       "Package": "xml2",
       "Version": "1.3.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "40682ed6a969ea5abfd351eb67833adc"
     },
     "yaml": {


### PR DESCRIPTION
- Resolved some inconsistencies re. package installation/loading and function calls.
    - Code was relying on `tidyverse` packages being loaded in namespace in some cases e.g. using `n()` rather than `dplyr::n()`, whereas obviously the general ethos is encouraging library calls with function calls. This was inconsistent and potentially confusing as it makes the code unclear, so I put `dplyr` calls throughout.
    - Given the above change, I thought it would make sense to replace the otherwise now unnecessary `library('tidyverse')` with `library('magrittr')` as use of `%>%` does mean that we need to load this one, which is otherwise loaded as dependency of `tidyverse`. All code now runs without `tidyverse` being loaded.
    - Users will now run `renv::install('tidyverse')` rather than `install.packages('tidyverse')`. This  will update the version of tidyverse packages to 2.0, which is more recent than the version on the AP, and we explain this as such.
    - Also have removed the bit about needing to load lubridate.
    - I realised halfway through making these changes that the way the course was written, the users were first told about loading packages before then being told to call the package with the function call. I don't know if this was deliberate or not, but I feel that front-loading the second approach and ensuring consistency by not loading `tidyverse` is better, pedagogically speaking - while at the same time still teaching them how to load a library where it is necessary.

- Added the `.groups = 'keep'` argument to ensure that calls to `dplyr::summarise()` retain the piped groups (this may have worked before but it was broken as of tidyverse 2.0).

- Removed references to `Rs3tools` in the markdown file, etc., which is no longer in the participant code.

- Added explicit keyword arguments.

- Other tidying.

- Some dead links updated on README.